### PR TITLE
Add an interception seam for property-testing engines

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
  (name splittable_random)
  (public_name splittable_random)
+ (inline_tests)
  (libraries base capsule0.prim)
  (preprocess
   (pps ppx_assert ppx_bench ppx_inline_test ppx_sexp_message)))

--- a/src/splittable_random.ml
+++ b/src/splittable_random.ml
@@ -34,17 +34,39 @@ let popcount x = Int64.popcount x
 type t =
   { mutable seed : int64
   ; odd_gamma : int64
+  ; intercept : intercept option
+  }
+
+(* Interception hooks for property-testing engines (see the [Intercept]
+   module below). [None] is the default and costs one branch per draw. *)
+and intercept =
+  { int64 :
+      t -> lo:int64 -> hi:int64 -> default:(t -> lo:int64 -> hi:int64 -> int64) -> int64
+  ; float :
+      t -> lo:float -> hi:float -> default:(t -> lo:float -> hi:float -> float) -> float
+  ; unit_float : t -> default:(t -> float) -> float
+  ; bool : t -> default:(t -> bool) -> bool
+  ; on_split : unit -> unit
+  ; on_perturb : unit -> unit
   }
 
 (* Alias used below when [t] is shadowed. *)
 type state = t
 
 let golden_gamma = 0x9e37_79b9_7f4a_7c15L
-let of_int seed = { seed = unbox (Int64.of_int seed); odd_gamma = unbox golden_gamma }
-let copy { seed; odd_gamma } = { seed; odd_gamma }
+let of_int seed =
+  { seed = unbox (Int64.of_int seed); odd_gamma = unbox golden_gamma; intercept = None }
+;;
 
-let copy_into_capsule { seed; odd_gamma } =
-  Capsule_prim.Data.create (fun () -> { seed; odd_gamma })
+let copy { seed; odd_gamma; intercept } = { seed; odd_gamma; intercept }
+
+(* Hooks are ordinary closures, so they cannot cross a capsule boundary:
+   the copy in the capsule is hook-free, and the closure below captures
+   only immediates. *)
+let copy_into_capsule t =
+  let seed = t.seed
+  and odd_gamma = t.odd_gamma in
+  Capsule_prim.Data.create (fun () -> { seed; odd_gamma; intercept = None })
 ;;
 
 let[@inline] mix_bits z n = z lxor (z lsr n)
@@ -90,7 +112,7 @@ let next_seed t =
 let of_seed_and_gamma ~seed ~gamma =
   let seed = mix64 seed in
   let odd_gamma = mix_odd_gamma gamma in
-  { seed = unbox seed; odd_gamma = unbox odd_gamma }
+  { seed = unbox seed; odd_gamma = unbox odd_gamma; intercept = None }
 ;;
 
 let random_int64 random_state =
@@ -104,15 +126,25 @@ let create random_state =
 ;;
 
 let split t =
+  (match t.intercept with
+   | None -> ()
+   | Some i -> i.on_split ());
   let seed = next_seed t in
   let gamma = next_seed t in
   of_seed_and_gamma ~seed ~gamma
 ;;
 
+(* Advances [t] exactly like [split], so observers get the same
+   notification. The state in the capsule is hook-free, like every state
+   this module constructs, and the mixing happens before capsule
+   creation so the closure below captures only immediates. *)
 let split_into_capsule t =
-  let seed = next_seed t in
-  let gamma = next_seed t in
-  Capsule_prim.Data.create (fun () -> of_seed_and_gamma ~seed ~gamma)
+  (match t.intercept with
+   | None -> ()
+   | Some i -> i.on_split ());
+  let seed = unbox (mix64 (next_seed t)) in
+  let odd_gamma = unbox (mix_odd_gamma (next_seed t)) in
+  Capsule_prim.Data.create (fun () -> { seed; odd_gamma; intercept = None })
 ;;
 
 let next_int64 t = mix64 (next_seed t)
@@ -120,11 +152,20 @@ let next_int64 t = mix64 (next_seed t)
 (* [perturb] is not from any external source, but provides a way to mix in external
    entropy with a pseudo-random state. *)
 let perturb t salt =
+  (match t.intercept with
+   | None -> ()
+   | Some i -> i.on_perturb ());
   let next = box t.seed + mix64 (Int64.of_int salt) in
   t.seed <- unbox next
 ;;
 
-let bool state = is_odd (next_int64 state)
+let bool_default state = is_odd (next_int64 state)
+
+let bool state =
+  match state.intercept with
+  | None -> bool_default state
+  | Some i -> i.bool state ~default:bool_default
+;;
 
 (* We abuse terminology and refer to individual values as biased or unbiased. More
    properly, what is unbiased is the sampler that results if we keep only these "unbiased"
@@ -158,7 +199,7 @@ let%test_unit "remainder_is_unbiased" =
 (* This implementation of bounded randomness is adapted from [Random.State.int*] in the
    OCaml standard library. The purpose is to use the minimum number of calls to
    [next_int64] to produce a number uniformly chosen within the given range. *)
-let int64 =
+let int64_default =
   let rec between state ~lo ~hi =
     let draw = next_int64 state in
     if lo <= draw && draw <= hi then draw else between state ~lo ~hi
@@ -183,6 +224,12 @@ let int64 =
     else if diff >= 0L
     then non_negative_up_to state diff + lo
     else between state ~lo ~hi
+;;
+
+let int64 state ~lo ~hi =
+  match state.intercept with
+  | None -> int64_default state ~lo ~hi
+  | Some i -> i.int64 state ~lo ~hi ~default:int64_default
 ;;
 
 let int state ~lo ~hi =
@@ -237,7 +284,13 @@ let%test_unit "unit_float_from_int64" =
   assert (unit_float_from_int64 0xffff_ffff_ffff_ffffL = 1.0 - double_ulp)
 ;;
 
-let unit_float state = unit_float_from_int64 (next_int64 state)
+let unit_float_default state = unit_float_from_int64 (next_int64 state)
+
+let unit_float state =
+  match state.intercept with
+  | None -> unit_float_default state
+  | Some i -> i.unit_float state ~default:unit_float_default
+;;
 
 (* Note about roundoff error:
 
@@ -247,16 +300,20 @@ let unit_float state = unit_float_from_int64 (next_int64 state)
    with [x < 1.] such that [lo +. x *. (hi -. lo) = hi], so it would not be correct to
    document this as being exclusive of [hi].
 *)
-let float =
+let float_default =
+  (* Uses the [_default] internals: when a hook delegates to [default],
+     the fallback must not re-enter the hooks, or a single [float] draw
+     would be observed twice (once whole, once as its internal
+     [unit_float]/[bool] draws). *)
   let rec finite_float state ~lo ~hi =
     let range = hi -. lo in
     if Float.is_finite range
-    then lo +. (unit_float state *. range)
+    then lo +. (unit_float_default state *. range)
     else (
       (* If [hi - lo] is infinite, then [hi + lo] is finite because [hi] and [lo] have
          opposite signs. *)
       let mid = (hi +. lo) /. 2. in
-      if bool state
+      if bool_default state
          (* Depending on rounding, the recursion with [~hi:mid] might be inclusive of
             [mid], which would mean the two cases overlap on [mid]. The alternative is to
             increment or decrement [mid] using [one_ulp] in either of the calls, but then
@@ -273,6 +330,12 @@ let float =
     if Float.( > ) lo hi
     then raise_s [%message "float: bounds are crossed" (lo : float) (hi : float)];
     finite_float state ~lo ~hi
+;;
+
+let float state ~lo ~hi =
+  match state.intercept with
+  | None -> float_default state ~lo ~hi
+  | Some i -> i.float state ~lo ~hi ~default:float_default
 ;;
 
 let%bench_fun "unit_float_from_int64" =
@@ -393,6 +456,88 @@ module Log_uniform = struct
   let int64 = For_int64.log_uniform
   let nativeint = For_nativeint.log_uniform
 end
+
+module Intercept = struct
+  type state = t
+
+  type t = intercept =
+    { int64 :
+        state
+        -> lo:int64
+        -> hi:int64
+        -> default:(state -> lo:int64 -> hi:int64 -> int64)
+        -> int64
+    ; float :
+        state
+        -> lo:float
+        -> hi:float
+        -> default:(state -> lo:float -> hi:float -> float)
+        -> float
+    ; unit_float : state -> default:(state -> float) -> float
+    ; bool : state -> default:(state -> bool) -> bool
+    ; on_split : unit -> unit
+    ; on_perturb : unit -> unit
+    }
+end
+
+let with_intercept t intercept = { t with intercept = Some intercept }
+
+let%test_unit "intercept observes every bounded draw with its bounds, and the \
+               derived draws delegate through [int64]" =
+  let observed = ref [] in
+  let intercept : Intercept.t =
+    { int64 =
+        (fun state ~lo ~hi ~default ->
+          observed := (lo, hi) :: !observed;
+          default state ~lo ~hi)
+    ; float = (fun state ~lo ~hi ~default -> default state ~lo ~hi)
+    ; unit_float = (fun state ~default -> default state)
+    ; bool = (fun state ~default -> default state)
+    ; on_split = (fun () -> ())
+    ; on_perturb = (fun () -> ())
+    }
+  in
+  let state = with_intercept (of_int 1) intercept in
+  let (_ : int) = int state ~lo:3 ~hi:17 in
+  let (_ : Int63.t) = int63 state ~lo:(Int63.of_int 5) ~hi:(Int63.of_int 5) in
+  [%test_result: (int64 * int64) list] !observed ~expect:[ 5L, 5L; 3L, 17L ]
+;;
+
+let%test_unit "intercept can force replayed values through the public API" =
+  let intercept : Intercept.t =
+    { int64 = (fun _ ~lo ~hi:_ ~default:_ -> lo)
+    ; float = (fun _ ~lo ~hi:_ ~default:_ -> lo)
+    ; unit_float = (fun _ ~default:_ -> 0.)
+    ; bool = (fun _ ~default:_ -> false)
+    ; on_split = (fun () -> ())
+    ; on_perturb = (fun () -> ())
+    }
+  in
+  let state = with_intercept (of_int 1) intercept in
+  [%test_result: int] (int state ~lo:42 ~hi:1000) ~expect:42;
+  [%test_result: bool] (bool state) ~expect:false
+;;
+
+let%test_unit "split-off states are hook-free and notify on_split" =
+  let splits = ref 0 in
+  let intercept : Intercept.t =
+    { int64 = (fun _ ~lo ~hi:_ ~default:_ -> lo)
+    ; float = (fun _ ~lo ~hi:_ ~default:_ -> lo)
+    ; unit_float = (fun _ ~default:_ -> 0.)
+    ; bool = (fun _ ~default:_ -> false)
+    ; on_split = (fun () -> Int.incr splits)
+    ; on_perturb = (fun () -> ())
+    }
+  in
+  let state = with_intercept (of_int 1) intercept in
+  let child = split state in
+  [%test_result: int] !splits ~expect:1;
+  let all_forced = ref true in
+  for _ = 1 to 100 do
+    if Int.( <> ) (int child ~lo:7 ~hi:1_000_000) 7 then all_forced := false
+  done;
+  [%test_result: bool] !all_forced ~expect:false
+;;
 
 module State = struct
   type t = state

--- a/src/splittable_random.mli
+++ b/src/splittable_random.mli
@@ -50,6 +50,47 @@ val split : t -> t
 val split_into_capsule : t -> (t, 'k) Capsule_prim.Data.t
 
 (** Legacy aliases for the preceding definitions. *)
+(** Interception hooks for property-testing engines that need to observe,
+    record, or replay the stream of bounded draws (for example, choice-tape
+    shrinkers in the style of Python Hypothesis's Conjecture engine).
+
+    A state carrying hooks consults them on each draw, passing the default
+    sampler so the hook can fall back to ordinary sampling; states without
+    hooks (the default, and everything this module constructs itself) behave
+    exactly as before, at the cost of one branch per draw. All bounded
+    integer draws ([int], [int32], [int63], [nativeint], and [Log_uniform])
+    delegate to [int64], so the [int64] hook observes every one of them with
+    its bounds. *)
+module Intercept : sig
+  type state := t
+
+  type t =
+    { int64 :
+        state
+        -> lo:int64
+        -> hi:int64
+        -> default:(state -> lo:int64 -> hi:int64 -> int64)
+        -> int64
+    ; float :
+        state
+        -> lo:float
+        -> hi:float
+        -> default:(state -> lo:float -> hi:float -> float)
+        -> float
+    ; unit_float : state -> default:(state -> float) -> float
+    ; bool : state -> default:(state -> bool) -> bool
+    ; on_split : unit -> unit
+    ; on_perturb : unit -> unit
+    }
+end
+
+(** [with_intercept t hooks] is a state sharing [t]'s underlying PRNG whose
+    draws consult [hooks]. [copy] preserves hooks; [split] produces
+    hook-free states (after calling [on_split], so an observer can keep its
+    record aligned); [perturb] calls [on_perturb] before mixing in the
+    salt. *)
+val with_intercept : t -> Intercept.t -> t
+
 module State : sig
   type nonrec t = t
 


### PR DESCRIPTION
This adds an optional `Intercept` record to `Splittable_random.t`: hooks for `int64`, `float`, `unit_float`, and `bool` (each receiving the default sampler as a fallback), plus `on_split` and `on_perturb` notifications. States without hooks, including everything the module constructs itself, behave exactly as before at the cost of one branch per draw; `split`-off states are hook-free.

The seam is small because of a nice property of this module's design: `int`, `int32`, `int63`, `nativeint`, and all of `Log_uniform` delegate to `int64`, so a single hook observes every bounded integer draw together with its bounds.

## Why

When a property-based test fails, the quality of the report depends on shrinking: turning the raw failing input (say, a 40-element list of nine-digit numbers) into a minimal one (say, `[100]`). base_quickcheck's `Shrinker.t` model shrinks values after the fact, and a value shrinker cannot know what the generator would have been willing to produce: halve an even number and you may hand an odd one to a test that assumed evenness. base_quickcheck resolves that dilemma safely but severely, by not shrinking scalars at all (`Shrinker.int` and friends are `atomic`), and by having no derivable shrinker for generators built with `bind`, where the shape of later draws depends on earlier values.

There is a model that dissolves the dilemma instead of picking a side, used by Python's Hypothesis: record every random decision the generator makes as a typed, bounded choice; shrink by editing the recorded tape and running the generator again on it, accepting the edit only if the test still fails and the recording got shorter or simpler. A shrink proposal is not a value but an input to the generator, so whatever comes out has passed through every filter, smart constructor, and dependent bind, exactly like the original. Invariants cannot be violated by construction, scalars shrink to their boundaries, and bind-shaped generators shrink through the dependency (lower the length draw, replay, and the generator rebuilds a consistent shorter list).

This PR adds the seam such an engine needs, and nothing else: no engine in this library, no behavior change without hooks. Because every base_quickcheck generator draws through `Splittable_random` and the primitives already carry their bounds, hooks here cover every existing generator, including everything `[@@deriving quickcheck]` produces, with zero changes to user code.

A complete working engine runs on this seam today: https://github.com/matthiasgoergens/tapecheck. Measured there over six properties and 100 seeds each, with identical failing examples handed to both shrinkers: the stock greedy `Shrinker.t` loop was fully minimal on 0/600 cases, the tape engine on 600/600, at 22 to 466 test executions per shrink. The repo's README and design notes have the details, including two findings about generator structure that the tape surfaced (`int_inclusive`'s constant branches trap shortlex shrinking, and `list_generic` spends several draws per element).

## Implementation notes for reviewers

- Hook fallbacks are non-reentrant: `float`'s default samples via the unhooked `unit_float`/`bool` internals, so a hooked `float` draw is observed exactly once. (Getting this wrong double-records and desyncs replay; the tapecheck round-trip test catches it.)
- The patch is based on the released v0.17 line (the v0.17.0 tag) because the public toolchain cannot build this mirror's master: it needs capsule0.prim, which is ahead of the published 5.2.0+ox overlay. It builds clean and passes its inline tests (three new ones cover observation with bounds, forced replay through the public API, and split notification) on stock OCaml 5.3. Porting to master raises a real design question, below.

## Open design question

The OxCaml mode checker raised this before any human saw the patch: with hooks carried inside `t`, a hooked state is nonportable data, which conflicts with `copy_into_capsule`/`split_into_capsule` on master and with treating draw-closures as portable in general. The options seem to be: require hook fields to be portable (data-race freedom composes, but recording observers inherently capture mutable state, so they would need capsule discipline); give the field a nonportable modality and keep the capsule constructors hook-free (what this patch does semantically: capsule copies drop hooks); or hold the hooks outside `t` in a wrapper type (which pushes a type change onto every caller and defeats the zero-changes goal). We would value your guidance.
